### PR TITLE
Allow to skip binaries signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,4 +113,4 @@ The `win.signCommand` parameter in the `params.json` file allows you to sign the
 
 The `mac.codesignIdentity`, `mac.codesignEntitlements`, `mac.teamID`, `mac.appleID`, and `mac.password` parameters in the `params.json` file allow you to sign and notarize the macOS app bundle.
 
-If you want to skip this step, add `-s` p
+If you want to skip this step, add `-s` parameter to the command.

--- a/README.md
+++ b/README.md
@@ -112,3 +112,5 @@ If you want to deploy the customized Chromium binaries with your software, you n
 The `win.signCommand` parameter in the `params.json` file allows you to sign the Windows executable.
 
 The `mac.codesignIdentity`, `mac.codesignEntitlements`, `mac.teamID`, `mac.appleID`, and `mac.password` parameters in the `params.json` file allow you to sign and notarize the macOS app bundle.
+
+If you want to skip this step, add `-s` p

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,12 +36,14 @@ const (
 	binariesDirFlag       = "binaries_dir"
 	jsonPathFlag          = "params"
 	outputBinariesDirFlag = "output_dir"
+	skipSigningFrag       = "skip_signing"   
 	verboseFlag           = "verbose"
 )
 
 var jsonPath string
 var binariesDir string
 var outputDirPath string
+var skipSigning bool
 var verbose bool
 
 var rootCmd = &cobra.Command{
@@ -72,12 +74,14 @@ var rootCmd = &cobra.Command{
 			return fmt.Errorf("failed to brand Chromium binaries: %w", err)
 		}
 
-		if _, err := core.SignAppBinaries(outputDirPath, *params); err != nil {
-			return err
-		}
+		if !skipSigning {
+			if _, err := core.SignAppBinaries(outputDirPath, *params); err != nil {
+				return err
+			}
 
-		if _, err = mac.Notarize(outputDirPath, *params); err != nil {
-			return err
+			if _, err = mac.Notarize(outputDirPath, *params); err != nil {
+				return err
+			}	
 		}
 
 		return nil
@@ -101,6 +105,8 @@ func init() {
 		`absolute path to the JSON file with the custom branding parameters`)
 	rootCmd.Flags().StringVarP(&outputDirPath, outputBinariesDirFlag, "o", "",
 		`absolute path to the directory where the branded Chromium binaries will be stored`)
+	rootCmd.Flags().BoolVarP(&skipSigning, skipSigningFrag, "s", false,
+		`skips binaries signing`)	
 	rootCmd.Flags().BoolVarP(&verbose, verboseFlag, "v", false,
 		`enable verbose output`)
 }


### PR DESCRIPTION
In this changeset, we add `-s` parameter that allows to skip signing process.

There are circumstances when signing is optional:

- App developers may simply not want to sign the binaries.
- Branding may be one of the early build steps. And signing is often the last step of the build.
- Branding can happen in the environment that doesn't have credentials for signing.