### PR TITLE
Allow to copy a custom `Info.plist` into the app bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Go workspace file
+go.work
+go.work.sum
+
+# env file
+.env
+
+# Current project macOS executable name
+Chromium-Branding

--- a/pkg/common/branding_params.go
+++ b/pkg/common/branding_params.go
@@ -71,11 +71,12 @@ type Mac struct {
 	// Bundle contains metadata related to the macOS application bundle.
 	Bundle *Bundle
 
-	TeamId               string
-	CodesignIdentity     string
-	CodesignEntitlements string
-	AppleId              string
-	Password             string
+	TeamId                  string
+	CodesignIdentity        string
+	CodesignEntitlements    string
+	AppleId                 string
+	Password                string
+	InformationPropertyList string
 }
 
 // Linux holds Linux-specific branding parameters.

--- a/pkg/mac/branding.go
+++ b/pkg/mac/branding.go
@@ -52,7 +52,14 @@ func (branding *MacBranding) ApplyToBundle(params *common.BrandingParams, appBun
 		BundleId:       params.Mac.Bundle.Id,
 	}
 
-	if err := cofigureBundlePlist(appBundle, appInfo); err != nil {
+	if params.Mac.InformationPropertyList != "" {
+		err := copyCustomPlist(appBundle, params.Mac.InformationPropertyList)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := configureBundlePlist(appBundle, appInfo); err != nil {
 		return err
 	}
 
@@ -142,7 +149,25 @@ func iconExpectedFor(appBundle ChromiumAppBundle) bool {
 	return appBundle.GetType() == CrBundleMain || appBundle.GetType() == CrBundleHelperAlerts
 }
 
-func cofigureBundlePlist(bundle ChromiumAppBundle, appInfo AppInfo) error {
+func copyCustomPlist(appBundle ChromiumAppBundle, customPlistPath string) error {
+	sourcePath, err := base.AbsPathFromPathString(customPlistPath)
+	if err != nil {
+		return err
+	}
+	sourceFile, err := sourcePath.AsFile()
+	if err != nil {
+		return err
+	}
+
+	destFile, err := appBundle.PlistFilePath().AsFile()
+	if err != nil {
+		return err
+	}
+
+	return destFile.Replace(sourceFile)
+}
+
+func configureBundlePlist(bundle ChromiumAppBundle, appInfo AppInfo) error {
 	return base.AnyErrorFrom(
 		overrideBundleName(bundle, appInfo.ExecutableName),
 		overrideBundleId(bundle, appInfo.BundleId),


### PR DESCRIPTION
In this changeset, we do the following:
1. Provide the `Info.plist` that is copied into the app bundle.
2. Add `.gitignore` to the project.
3. Fixes the typo.  

Issue: https://github.com/TeamDev-IP/Chromium-Branding/issues/13