### PR TITLE
Change release job agent

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,8 +94,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macos-13 stands for x86, macos-latest is ARM build.
-        os: [macos-13, macos-latest]
+        # macos-15-intel stands for x86, macos-latest is ARM build.
+        os: [macos-15-intel, macos-latest]
 
     steps:
       - name: Check out source


### PR DESCRIPTION
Problem: GitHub has removed its `macOS-13 agent`. Triggering the release workflow now always fails. 
Solution: change the agent to the supported one: `macOS-15-intel`. 
The list of available agents can be found here.
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#standard-github-hosted-runners-for-public-repositories