### PR TITLE
Fix the draft job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -191,7 +191,7 @@ jobs:
           mv dist/ubuntu-latest-build/chromium_branding-ubuntu-latest.zip dist/ubuntu-latest-build/chromium_branding_linux_x64.zip
           mv dist/windows-latest-build/chromium_branding.zip dist/windows-latest-build/chromium_branding_win_x64.zip
           mv dist/macos-latest-build/chromium_branding-macos-latest.zip dist/macos-latest-build/chromium_branding_mac_arm64.zip
-          mv dist/macos-13-build/chromium_branding-macos-13.zip dist/macos-13-build/chromium_branding_mac_x64.zip
+          mv dist/macos-15-intel-build/chromium_branding-macos-15-intel.zip dist/macos-15-intel-build/chromium_branding_mac_x64.zip
 
       - name: Create GitHub Release draft
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
@@ -200,7 +200,7 @@ jobs:
             dist/windows-latest-build/*
             dist/ubuntu-latest-build/*
             dist/macos-latest-build/*
-            dist/macos-13-build/*
+            dist/macos-15-intel-build/*
           tag_name: ${{ github.ref_name }}
           name: "${{ github.ref_name }}"
           draft: true


### PR DESCRIPTION
The build job fails because it expects the x86_64 macOS artifact be named macos-13. However, it has a different name. 