### PR TITLE
Restore icon branding in the recent macOS bundles

### DIFF
--- a/pkg/mac/branding.go
+++ b/pkg/mac/branding.go
@@ -71,6 +71,16 @@ func (branding *MacBranding) ApplyToBundle(params *common.BrandingParams, appBun
 		if err := configureBundleIcon(appBundle, iconPath); err != nil {
 			return err
 		}
+		plistFile, err := appBundle.PlistFilePath().AsFile()
+		if err != nil {
+			return err
+		}
+		if _, err := getPlistProperty(plistFile, "CFBundleIconName"); err == nil {
+			// Delete the property only in the newer Chromium bundles where it's present.
+			if err := deletePlistProperty(plistFile, "CFBundleIconName"); err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil
@@ -207,8 +217,17 @@ func overrideBundleProperties(bundle ChromiumAppBundle, properties []string, val
 	return nil
 }
 
+func getPlistProperty(plist base.File, key string) (string, error) {
+	return base.ExecCommandAndGetOutput("defaults", []string{"read", plist.AbsPath().String(), key})
+}
+
 func setPlistProperty(plist base.File, key, value string) error {
 	return base.ExecCommand("defaults", []string{"write", plist.AbsPath().String(), key, "\"" + value + "\""})
+}
+
+func deletePlistProperty(plist base.File, key string) error {
+	base.ExecCommand("defaults", []string{"delete", plist.AbsPath().String(), key})
+	return nil
 }
 
 func overrideBundleName(bundle ChromiumAppBundle, name *string) error {

--- a/pkg/mac/branding.go
+++ b/pkg/mac/branding.go
@@ -75,9 +75,9 @@ func (branding *MacBranding) ApplyToBundle(params *common.BrandingParams, appBun
 		if err != nil {
 			return err
 		}
-		if _, err := getPlistProperty(plistFile, "CFBundleIconName"); err == nil {
+		if _, err := getPlistProperty(plistFile, bundleIconNameAssetProperty); err == nil {
 			// Delete the property only in the newer Chromium bundles where it's present.
-			if err := deletePlistProperty(plistFile, "CFBundleIconName"); err != nil {
+			if err := deletePlistProperty(plistFile, bundleIconNameAssetProperty); err != nil {
 				return err
 			}
 		}
@@ -140,6 +140,8 @@ func (branding *MacBranding) ExecutableName(params *common.BrandingParams) strin
 	}
 	return "Chromium"
 }
+
+const bundleIconNameAssetProperty = "CFBundleIconName"
 
 var bundleIdProperties = []string{
 	"CFBundleIdentifier",


### PR DESCRIPTION
In the recent Chromium versions, macOS bundles moved to using asset catalogs in the form of `.car` files or **resource catalogs**. They have added the [new tooling](https://source.chromium.org/chromium/chromium/src/+/main:tools/mac/icons/compile_car.py) to generate `.car` files for the macOS bundles. They use [custom icon name](https://source.chromium.org/chromium/chromium/src/+/main:tools/mac/icons/compile_car.py;l=226),  that they [use](https://source.chromium.org/chromium/chromium/src/+/main:chrome/app/app-Info.plist;l=152?q=CFBundleIconName&ss=chromium%2Fchromium%2Fsrc) in the bundle `.plist` file.

This turned out to make the bundle trying to use the icon from the resource catalog, that is a binary file and is [not trivial to recompose](https://source.chromium.org/chromium/chromium/src/+/main:tools/mac/icons/compile_car.py).

### Solution

To restore the previous behavior, it is enough to just remove this property from the app bundle `.plist`.

Issue: #14 