### PR TITLE
Build the tool without the C runtime dependency

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,7 @@ jobs:
           go-version: '1.20'
       - name: Build
         run: |
+            $Env:CGO_ENABLED = "0"
             go build -o chromium_branding.exe .
 
       - name: Install Yubico
@@ -80,7 +81,7 @@ jobs:
           go-version: '1.20'
       - name: Build
         run: |
-            go build -o chromium_branding .
+            CGO_ENABLED=0 go build -o chromium_branding .
             zip chromium_branding-ubuntu-latest.zip chromium_branding
 
       - name: Upload artifact

--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ Run the following command in the root directory of the repository:
 ### Windows
 
 ```sh
+set CGO_ENABLED=0
 go build -o chromium_branding.exe
 ```
 
 ### macOS/Linux
 
 ```sh
-go build -o chromium_branding
+CGO_ENABLED=0 go build -o chromium_branding
 ```
 
 You will find the `chromium_branding(.exe)` executable there.


### PR DESCRIPTION
Issue: #20

We have recently noticed that the tool is not run on the older Linux distributions, for example Ubuntu 20.04 - it requires the specific minimum GLIBC version.
 
It turned out that the problem is causes that Go implicitly uses `CGO_ENABLED=1`, so the Chromium Branding is built with the C runtime by default.

This PR updates the CI and build instruction to produce the truly standalone platform binary.