### PR TITLE
Build without C runtime on macOS

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Build
         run: |
-            go build -o chromium_branding .
+            CGO_ENABLED=0 go build -o chromium_branding .
 
       - name: Set up keychain, sign, and notarize
         env:


### PR DESCRIPTION
This PR adds `CGO_ENABLED=0` flag for macOS build on GitHub Actions runners.