### PR TITLE
Fix the parameter name for Linux executable

### DIFF
--- a/pkg/common/branding_params.go
+++ b/pkg/common/branding_params.go
@@ -81,9 +81,9 @@ type Mac struct {
 
 // Linux holds Linux-specific branding parameters.
 type Linux struct {
-	// ProcessName is the name of the running process (e.g., the
+	// ExecutableName is the name of the running process (e.g., the
 	// display in system monitors or process listings).
-	ProcessName *string
+	ExecutableName *string
 }
 
 // BrandingParams holds versioning and platform-specific branding

--- a/pkg/linux/branding.go
+++ b/pkg/linux/branding.go
@@ -47,8 +47,8 @@ func (branding *LinuxBranding) ExecutableNameFile(params *common.BrandingParams,
 // ExecutableName returns the Linux process name from BrandingParams if set,
 // or defaults to "chromium" otherwise.
 func (branding *LinuxBranding) ExecutableName(params *common.BrandingParams) string {
-	if params.Linux.ProcessName != nil {
-		return *params.Linux.ProcessName
+	if params.Linux.ExecutableName != nil {
+		return *params.Linux.ExecutableName
 	}
 
 	return originalChromiumExeName
@@ -72,8 +72,8 @@ func (branding *LinuxBranding) Apply(params *common.BrandingParams, binariesDir 
 		return nil
 	}
 
-	if params.Linux.ProcessName != nil {
-		if err := chromiumExe.Rename(*params.Linux.ProcessName); err != nil {
+	if params.Linux.ExecutableName != nil {
+		if err := chromiumExe.Rename(*params.Linux.ExecutableName); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This PR fixes the mismatch between the parameter name we use in JSON and the name we declare in `BrandingParams` in our code.

In our code we use standard Go JSON parsing API, that automatically maps Go `struct` fields to the lowercase JSON ones. We should have `Linux.ExecutableName` instead of `Linux.ProcessName` for consistency.
